### PR TITLE
feat: APM & robots.txt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@
 ## Number of Puma processes to run.
 ## Defaults to 2
 # WEB_CONCURRENCY=
+
+## Elastic APM config.
+## See: https://www.elastic.co/guide/en/apm/agent/ruby/current/configuration.html
+# ELASTIC_APM_SERVER_URL=https://apm.eanadev.org:8200
+# ELASTIC_APM_ENVIRONMENT=production
+
+## Content of robots.txt
+## Default disallows indexing.
+# ROBOTS_TXT=

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ ENV RACK_ENV=production \
     ELASTIC_APM_SERVICE_NAME=media-proxy \
     ELASTIC_APM_ENVIRONMENT=development
 
-ENTRYPOINT ["bundle", "exec", "puma"]
-CMD ["-C", "config/puma.rb", "-v"]
-EXPOSE ${PORT}
-
 WORKDIR /app
 
 RUN apk add --update \
@@ -31,7 +27,12 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle config set without "development test" && \
     bundle install --jobs=3 --retry=3
 
+
 FROM base
+
+ENTRYPOINT ["bundle", "exec", "puma"]
+CMD ["-C", "config/puma.rb", "-v"]
+EXPOSE ${PORT}
 
 COPY --from=dependencies /usr/local/bundle/ /usr/local/bundle/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV RACK_ENV=production \
 
 ENTRYPOINT ["bundle", "exec", "puma"]
 CMD ["-C", "config/puma.rb", "-v"]
-EXPOSE 8080
+EXPOSE ${PORT}
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,38 @@
-FROM ruby:2.5.5-alpine
+FROM ruby:2.5.5-alpine AS base
 
 MAINTAINER Europeana Foundation <development@europeana.eu>
 
-ENV BUNDLE_WITHOUT development:test
-ENV RACK_ENV production
-ENV PORT 80
-
-WORKDIR /app
-
-COPY Gemfile Gemfile.lock ./
-
-# Install dependencies
-RUN apk update && \
-    apk add --no-cache --virtual .build-deps \
-      build-base \
-      git && \
-    apk add --no-cache --virtual .runtime-deps \
-      libcurl && \
-    echo "gem: --no-document" >> /etc/gemrc && \
-    bundle install --deployment --without ${BUNDLE_WITHOUT} --jobs=4 --retry=4 && \
-    rm -rf vendor/bundle/ruby/2.5.0/bundler/gems/*/.git && \
-    rm -rf vendor/bundle/ruby/2.5.0/cache && \
-    rm -rf /root/.bundle && \
-    apk del .build-deps && \
-    rm -rf /var/cache/apk/*
-
-# Copy code
-COPY . .
-
-EXPOSE 80
+ENV RACK_ENV=production \
+    BUNDLER_VERSION=2.1.4 \
+    PORT=8080 \
+    WEB_CONCURRENCY=1 \
+    ELASTIC_APM_SERVICE_NAME=media-proxy \
+    ELASTIC_APM_ENVIRONMENT=development
 
 ENTRYPOINT ["bundle", "exec", "puma"]
 CMD ["-C", "config/puma.rb", "-v"]
+EXPOSE 8080
+
+WORKDIR /app
+
+RUN apk add --update \
+  libcurl
+
+RUN gem install bundler -v ${BUNDLER_VERSION}
+
+
+FROM base as dependencies
+
+RUN apk add --update \
+  build-base
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle config set without "development test" && \
+    bundle install --jobs=3 --retry=3
+
+FROM base
+
+COPY --from=dependencies /usr/local/bundle/ /usr/local/bundle/
+
+COPY . ./

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,13 @@ source 'https://rubygems.org'
 
 gem 'activesupport'
 gem 'addressable'
+gem 'elastic-apm'
 gem 'europeana-api'
 gem 'http_logger'
 gem 'mime-types'
 gem 'puma'
 gem 'rack'
-# Pending release > 1.0.2
-gem 'rack-cors', git: 'https://github.com/cyu/rack-cors.git', ref: '51f5c534d968d8ed89ae25f4aa4e93d16cc115f1'
+gem 'rack-cors', '~> 1.0.3'
 gem 'rack-proxy'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/cyu/rack-cors.git
-  revision: 51f5c534d968d8ed89ae25f4aa4e93d16cc115f1
-  ref: 51f5c534d968d8ed89ae25f4aa4e93d16cc115f1
-  specs:
-    rack-cors (1.0.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -20,7 +13,12 @@ GEM
     daemons (1.2.6)
     diff-lcs (1.3)
     docile (1.3.1)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
+    elastic-apm (4.5.1)
+      concurrent-ruby (~> 1.0)
+      http (>= 3.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
     europeana-api (1.1.0)
@@ -36,8 +34,21 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.25)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     foreman (0.85.0)
       thor (~> 0.19.1)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
     http_logger (0.5.1)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
@@ -57,6 +68,8 @@ GEM
     public_suffix (3.1.1)
     puma (3.12.0)
     rack (2.0.7)
+    rack-cors (1.0.6)
+      rack (>= 1.6.0)
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)
@@ -98,6 +111,9 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (1.4.0)
 
 PLATFORMS
@@ -108,13 +124,14 @@ DEPENDENCIES
   addressable
   daemons
   dotenv
+  elastic-apm
   europeana-api
   foreman
   http_logger
   mime-types
   puma
   rack
-  rack-cors!
+  rack-cors (~> 1.0.3)
   rack-proxy
   rack-test
   rake
@@ -124,4 +141,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/lib/europeana/media_proxy.rb
+++ b/lib/europeana/media_proxy.rb
@@ -9,6 +9,7 @@ module Europeana
     autoload :App, 'europeana/media_proxy/app'
     autoload :Errors, 'europeana/media_proxy/errors'
     autoload :Proxy, 'europeana/media_proxy/proxy'
+    autoload :RobotsTxt, 'europeana/media_proxy/robots_txt'
 
     class << self
       # @!attribute [r] logger

--- a/lib/europeana/media_proxy/app.rb
+++ b/lib/europeana/media_proxy/app.rb
@@ -15,6 +15,10 @@ module Europeana
           app = Europeana::MediaProxy::App.new
 
           use Rack::CommonLogger, Europeana::MediaProxy.logger
+          use ElasticAPM::Middleware
+          use Europeana::MediaProxy::RobotsTxt
+
+          ElasticAPM.start
 
           if ENV['CORS_ORIGINS']
             require 'rack/cors'
@@ -33,6 +37,8 @@ module Europeana
               streaming: app.streaming
 
           run app
+
+          at_exit { ElasticAPM.stop }
         end
       end
 

--- a/lib/europeana/media_proxy/robots_txt.rb
+++ b/lib/europeana/media_proxy/robots_txt.rb
@@ -1,0 +1,20 @@
+module Europeana
+  module MediaProxy
+    class RobotsTxt
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if env['PATH_INFO'] == '/robots.txt'
+          status = 200
+          headers = { 'Content-Type' => 'text/plain' }
+          body = [ENV['ROBOTS_TXT'] || "User-agent: *\nDisallow: /"]
+          [status, headers, body]
+        else
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/europeana/media_proxy/version.rb
+++ b/lib/europeana/media_proxy/version.rb
@@ -3,6 +3,6 @@
 module Europeana
   # Europeana::MediaProxy version
   module MediaProxy
-	  VERSION = '0.5.1'
+	  VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
* Add Elastic APM instrumentation, configurable by env var
* Add dynamic robots.txt configurable by env var, defaulting to disallow all bot traffic
* Update Dockerfile to use multi-stage build
* **Update default http port for Docker image from 80 to 8080**
* Switch rack-cors gem to use a published version, not Git ref
* Fix version number